### PR TITLE
Settings: Properly allign bottom preferences

### DIFF
--- a/res/xml/top_level_settings.xml
+++ b/res/xml/top_level_settings.xml
@@ -122,14 +122,14 @@
 
     <Preference
         android:key="top_level_system"
-        android:order="1"
+        android:order="150"
         android:title="@string/xd_dashboard_system"
         android:layout="@layout/xd_dashboard_pref_bot"
         android:fragment="com.android.settings.system.SystemDashboardFragment"/>
 
     <Preference
         android:key="top_level_support"
-        android:order="2"
+        android:order="200"
         android:title="@string/xd_dashboard_support"
         settings:controller="com.android.settings.support.SupportPreferenceController"/>
 


### PR DESCRIPTION
This fixes the device settings pref running out and making the whole layout look like a mess.

Before: https://imgur.com/a/Bo1RG9v
After: https://imgur.com/a/tyBFCUt